### PR TITLE
Fix use-after-free after destroying projectile

### DIFF
--- a/src/Engine/G_Game.c
+++ b/src/Engine/G_Game.c
@@ -429,8 +429,11 @@ void G_UpdateProjectiles(void)
                 if(cur->previous != NULL)
                     cur->previous->next = cur->next;
 
-                free(cur->this.animTimer);
-                free(cur);
+                projectileNode_t* dead = cur;
+                cur = cur->next;
+                free(dead->this.animTimer);
+                free(dead);
+                continue;
             }
         }
 


### PR DESCRIPTION
My game was crashing every time I got outside. The debug heap deliberately trashed the freed object so that it would crash like this.