### PR TITLE
Clamp texture sampling to avoid rounding errors

### DIFF
--- a/src/Engine/R_Rendering.c
+++ b/src/Engine/R_Rendering.c
@@ -2488,7 +2488,7 @@ void R_DrawStripeTexturedShaded(int x, int y, int endY, SDL_Surface* texture, in
         if(x < PROJECTION_PLANE_WIDTH && x >= 0 && i < PROJECTION_PLANE_HEIGHT && i >= 0) // Don't overflow
         {
             // Extract pixel
-            Uint32 pixel = R_GetPixelFromSurface(texture, xOffset, textureY);
+            Uint32 pixel = R_GetPixelFromSurface(texture, xOffset, SDL_clamp(textureY, 0, texture->h-1));
 
             if(dist < zBuffer[i][x] && pixel != r_transparencyColor)
             {


### PR DESCRIPTION
The loop accumulates floating point steps and sometimes due to rounding error it goes just slightly out of bounds, causing an out of bounds read. This change clamps the sample to the edge of the texture.